### PR TITLE
Restructure for webpack4

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -8,13 +8,12 @@ require('angular-route');
 
 var app = angular.module('todoApp', [ 'ngRoute' ]);
 
-app.constant('VERSION', require('json!../../package.json').version);
+app.constant('VERSION', require('../../package.json').version);
 
 require('./service');
 require('./controller');
 
 app.config(function($routeProvider) {
-
   $routeProvider.when('/todos', {
     template: require('../views/todos.html'),
     controller: 'TodoController',

--- a/app/js/controller/edit_todo.js
+++ b/app/js/controller/edit_todo.js
@@ -1,6 +1,7 @@
 'use strict';
+var app = require('angular').module('todoApp');
 
-module.exports = function($scope, TodoService) {
+app.controller('EditTodoController', function($scope, TodoService) {
 
   var backupForCancel;
   var creatingNew = false;
@@ -59,4 +60,4 @@ module.exports = function($scope, TodoService) {
       text: todo.text,
     };
   }
-};
+});

--- a/app/js/controller/footer.js
+++ b/app/js/controller/footer.js
@@ -1,5 +1,6 @@
 'use strict';
+var app = require('angular').module('todoApp');
 
-module.exports = function($scope, VERSION) {
+app.controller('FooterController', function($scope, VERSION) {
   $scope.version = VERSION;
-};
+});

--- a/app/js/controller/imprint.js
+++ b/app/js/controller/imprint.js
@@ -1,5 +1,6 @@
 'use strict';
+var app = require('angular').module('todoApp');
 
-module.exports = function($scope, ImprintService) {
-  $scope.text = ImprintService.getText();
-};
+app.controller('ImprintController', function($scope, ImprintService) {
+	$scope.text = ImprintService.getText();
+});

--- a/app/js/controller/index.js
+++ b/app/js/controller/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
-var app = require('angular').module('todoApp');
-
-app.controller('EditTodoController', require('./edit_todo'));
-app.controller('FooterController', require('./footer'));
-app.controller('TodoController', require('./todo'));
-app.controller('TodoListController', require('./todo_list'));
-app.controller('ImprintController', require('./imprint'));
+require('./edit_todo');
+require('./footer');
+require('./todo');
+require('./todo_list');
+require('./imprint');

--- a/app/js/controller/todo.js
+++ b/app/js/controller/todo.js
@@ -1,5 +1,6 @@
 'use strict';
+var app = require('angular').module('todoApp');
 
-module.exports = function($scope, TodoService) {
+app.controller('TodoController', function($scope, TodoService) {
   $scope.todo = TodoService.getTodos()[0];
-};
+});

--- a/app/js/controller/todo_list.js
+++ b/app/js/controller/todo_list.js
@@ -1,6 +1,7 @@
 'use strict';
+var app = require('angular').module('todoApp');
 
-module.exports = function($scope, TodoService) {
+app.controller('TodoListController', function($scope, TodoService) {
 
   $scope.getTodos = TodoService.getTodos.bind(TodoService);
 
@@ -16,4 +17,4 @@ module.exports = function($scope, TodoService) {
     }
   };
 
-};
+});

--- a/package.json
+++ b/package.json
@@ -6,20 +6,21 @@
   "scripts": {
     "postinstall": "./node_modules/protractor/bin/webdriver-manager update",
     "pretest": "./node_modules/protractor/bin/webdriver-manager start &",
-    "test": "./node_modules/gulp/bin/gulp.js"
+    "test": "./node_modules/gulp/bin/gulp.js",
+    "build": "webpack --config webpack.config.js"
   },
   "dependencies": {
     "angular": "^1.4.4",
     "angular-route": "^1.4.4",
-    "es5-shim": "^3.0.2",
-    "jquery": "^2.1.1"
+    "es5-shim": "^4.0.0",
+    "jquery": "^3.3.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",
-    "eslint": "^1.1.0",
-    "eslint-loader": "^1.0.0",
+    "eslint": "^5.12.1",
+    "eslint-loader": "^2.1.1",
     "eslint-plugin-angular": "^0.4.0",
-    "html-loader": "^0.3.0",
+    "html-loader": "^0.5.5",
     "json-loader": "^0.5.2",
     "karma": "^0.12.16",
     "karma-chai": "^0.1.0",
@@ -31,7 +32,9 @@
     "protractor": "^0.22.0",
     "sinon": "^1.9.1",
     "sinon-chai": "^2.5.0",
-    "webpack": "^1.11.0",
-    "webpack-dev-server": "^1.10.1"
+    "ng-annotate-loader": "^0.6.1",
+    "webpack": "^4.29.0",
+    "webpack-cli": "^3.2.1",
+    "webpack-dev-server": "^3.1.14"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,24 +9,29 @@ module.exports = {
         publicPath: '/dist/'
     },
     module: {
-        preLoaders: [
+        rules: [
             {
                 test: /\.js$/,
                 exclude: /node_modules/,
-                loader: 'eslint-loader'
-            }
-        ],
-        loaders: [
+                use: [
+                    {
+                        loader: 'ng-annotate-loader'
+                    },
+                    {
+                        loader: 'eslint-loader'
+                    }
+                ]
+            },
             {
                 test: /\.html$/,
-                loader: 'html-loader'
+                use: [
+                    'html-loader'
+                ]
             }
         ]
     },
-    eslint: {
-        configFile: './.eslintrc'
-    },
     devtool: 'source-map',
+    mode: 'production',
     devServer: {
         contentBase: path.join(__dirname, 'app')
     }


### PR DESCRIPTION
Hi Benedikt,

Firstly, thank-you for providing this project… I think a lot of the "examples" out there are just overly complicated -- the simple approach taken really helped work out what was "essential" to get the job done.

I'm not sure what license your project is under, if you could put that metadata into `package.json`, that'd be a big help to understanding where I stand in using the code there.

I couldn't get tests working at all -- not sure what I'm doing wrong, but the fact that you mention issues with Travis CI might be a factor -- I'm using Gentoo Linux AMD64 which isn't dissimilar to the Ubuntu environment that Travis CI runs.

I did manage to port the build environment to Webpack 4.  I found minification would break the application, even after getting the `ng-annotate-loader` module working because the way the functions for each controller were `require()`d in, confused the loader.  Moving the controller definition to the file where its function was defined fixed that, and now (in Firefox at least), I can use your application when minified by Webpack 4.

I might take another look at test frameworks, see if I can get them going here.  If I manage that, I might provide another pull request -- that might get Travis CI working too.

Regards,
Stuart Longland